### PR TITLE
feat: add cross-app full-text search

### DIFF
--- a/apps/core/search.py
+++ b/apps/core/search.py
@@ -1,0 +1,119 @@
+"""Cross-app search service for translated post types.
+
+PostgreSQL backend uses ``SearchVector + SearchQuery + SearchRank`` with the
+language-specific text-search config (``french``, ``english``, ``italian``)
+so stemming and stop-words match the user's content. SQLite (dev only)
+falls back to ``icontains`` chains so local development doesn't require
+Postgres. The dev fallback returns no rank but preserves the same shape so
+templates don't branch.
+
+Search is scoped to translations in the active language only — Google's
+hreflang strategy means each language is a distinct content surface, so
+mixing them in results would dilute relevance.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from django.db import connection
+from django.db.models import Case, Q, Value, When
+
+from apps.blog.models import Article, ArticleTranslation
+from apps.education.models import Lesson, LessonTranslation
+from apps.infosec.models import Writeup, WriteupTranslation
+
+# Map our short language codes to PostgreSQL ts_config names. Only languages
+# Postgres ships with by default — if you add e.g. Italian content and want
+# proper stemming, this map is the single place to update.
+PG_TEXT_SEARCH_CONFIG = {
+    "fr": "french",
+    "en": "english",
+    "it": "italian",
+}
+
+POST_TYPES = (
+    ("articles", Article, ArticleTranslation),
+    ("writeups", Writeup, WriteupTranslation),
+    ("lessons", Lesson, LessonTranslation),
+)
+
+
+@dataclass
+class SearchHit:
+    post: object  # Article | Writeup | Lesson
+    translation: object  # the matched *Translation row
+    rank: float  # 0.0 on SQLite fallback
+
+
+def search_posts(query: str, language: str) -> dict[str, list[SearchHit]]:
+    """Return matching posts grouped by type, ordered by rank desc."""
+    query = (query or "").strip()
+    if not query:
+        return {key: [] for key, _, _ in POST_TYPES}
+
+    if connection.vendor == "postgresql":
+        return _postgres_search(query, language)
+    return _fallback_search(query, language)
+
+
+def _postgres_search(query: str, language: str) -> dict[str, list[SearchHit]]:
+    from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
+
+    config = PG_TEXT_SEARCH_CONFIG.get(language, "simple")
+    search_query = SearchQuery(query, config=config, search_type="websearch")
+    vector = (
+        SearchVector("title", weight="A", config=config)
+        + SearchVector("description", weight="B", config=config)
+        + SearchVector("content", weight="C", config=config)
+    )
+
+    results: dict[str, list[SearchHit]] = {}
+    for key, post_model, translation_model in POST_TYPES:
+        translations = (
+            translation_model.objects.filter(language=language)
+            .annotate(rank=SearchRank(vector, search_query))
+            .filter(rank__gt=0)
+            .select_related("translatable_content")
+            .order_by("-rank")[:30]
+        )
+        results[key] = [
+            SearchHit(post=t.translatable_content, translation=t, rank=float(t.rank)) for t in _filter_published(translations, post_model)
+        ]
+    return results
+
+
+def _fallback_search(query: str, language: str) -> dict[str, list[SearchHit]]:
+    """SQLite-friendly substring search. Used in dev only — Postgres in prod."""
+    needle = Q(title__icontains=query) | Q(description__icontains=query) | Q(content__icontains=query)
+    # Bias title hits to the top so ordering is at least roughly useful.
+    rank_expr = Case(
+        When(title__icontains=query, then=Value(3.0)),
+        When(description__icontains=query, then=Value(2.0)),
+        default=Value(1.0),
+    )
+
+    results: dict[str, list[SearchHit]] = {}
+    for key, post_model, translation_model in POST_TYPES:
+        translations = (
+            translation_model.objects.filter(language=language)
+            .filter(needle)
+            .annotate(rank=rank_expr)
+            .select_related("translatable_content")
+            .order_by("-rank", "-id")[:30]
+        )
+        results[key] = [
+            SearchHit(post=t.translatable_content, translation=t, rank=float(t.rank)) for t in _filter_published(translations, post_model)
+        ]
+    return results
+
+
+def _filter_published(translations: Iterable, post_model) -> list:
+    """Drop hits whose parent post isn't publicly visible.
+
+    Lessons don't carry a ``visibility`` field — they're gated by the parent
+    Module/Course access, so we accept all of them here and let the existing
+    view-level checks handle restrictions.
+    """
+    if not hasattr(post_model, "visibility"):
+        return list(translations)
+    return [t for t in translations if getattr(t.translatable_content, "visibility", "public") == "public"]

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import index, page_detail, well_known
+from .views import index, page_detail, search_view, well_known
 
 app_name = "core"
 urlpatterns = [
     path("", index, name="index"),
+    path("search/", search_view, name="search"),
     path("pages/<slug:slug>/", page_detail, name="page_detail"),
     path(".well-known/<str:filename>", well_known, name="well_known"),
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -102,6 +102,24 @@ def ratelimited(request, exception):
     return response
 
 
+def search_view(request):
+    """Cross-app search across translated posts in the active language."""
+    from apps.core.search import search_posts
+
+    query = request.GET.get("q", "").strip()
+    results = search_posts(query, get_language()) if query else None
+    total = sum(len(v) for v in results.values()) if results else 0
+    return render(
+        request,
+        "core/search.html",
+        {
+            "query": query,
+            "results": results,
+            "total": total,
+        },
+    )
+
+
 def redirect_to_available_translation(post, url_name, url_args):
     """
     If the active language has no translation for ``post``, return a 301 to

--- a/themes/Eskoz/static/Eskoz/css/style.css
+++ b/themes/Eskoz/static/Eskoz/css/style.css
@@ -91,6 +91,53 @@ header {
   text-decoration: none;
 }
 
+.search-form {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1rem 0 1.5rem;
+}
+
+.search-form--input {
+  flex: 1;
+  padding: 0.6rem 0.9rem;
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.04));
+  color: var(--text);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.search-form--input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.search-form--button {
+  padding: 0.6rem 1.2rem;
+  background: var(--accent-gradient);
+  color: var(--bg-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.search-summary {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.search-group--title {
+  margin: 2rem 0 0.75rem;
+  font-size: 1rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
 .lang-switcher {
   position: relative;
   display: inline-block;

--- a/themes/Eskoz/templates/components/navbar.html
+++ b/themes/Eskoz/templates/components/navbar.html
@@ -69,6 +69,14 @@
                 <li class="navbar-item navbar-item--separator">/</li>
             {% endif %}
         {% endif %}
+        <li class="navbar-item navbar-item--search">
+            <a href="{% url 'core:search' %}" class="navbar-item--link" aria-label="{% trans 'Search' %}">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                    <circle cx="7" cy="7" r="5"/>
+                    <line x1="14" y1="14" x2="10.5" y2="10.5" stroke-linecap="round"/>
+                </svg>
+            </a>
+        </li>
         <li class="navbar-item navbar-item--lang">
             {% include "components/language_switcher.html" %}
         </li>

--- a/themes/Eskoz/templates/core/search.html
+++ b/themes/Eskoz/templates/core/search.html
@@ -1,0 +1,71 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %} - {% trans 'Search' %}{% if query %}: {{ query }}{% endif %}{% endblock %}
+{% block robots %}<meta name="robots" content="noindex,follow">{% endblock %}
+{% block og_title %}<meta property="og:title" content="{% trans 'Search' %} | {{ site_settings.site_name }}">{% endblock %}
+{% block meta_description %}<meta name="description" content="{% trans 'Search articles, writeups and lessons across the site.' %}">{% endblock %}
+
+{% block content %}
+<div class="article_list">
+    <div class="article_list--top">
+        <h2 class="article_list--title">{% trans 'Search' %}</h2>
+    </div>
+
+    <form method="get" action="{% url 'core:search' %}" class="search-form" role="search">
+        <input type="search" name="q" value="{{ query }}" placeholder="{% trans 'Search articles, writeups, lessons…' %}" autofocus aria-label="{% trans 'Search query' %}" class="search-form--input">
+        <button type="submit" class="search-form--button">{% trans 'Search' %}</button>
+    </form>
+
+    {% if query %}
+        <p class="search-summary">
+            {% blocktrans count counter=total %}{{ counter }} result for "{{ query }}"{% plural %}{{ counter }} results for "{{ query }}"{% endblocktrans %}
+        </p>
+
+        {% if total == 0 %}
+            <div class="message-wrapper">
+                <p>{% trans 'No matching content. Try different keywords or check the spelling.' %}</p>
+            </div>
+        {% else %}
+            {% if results.articles %}
+                <h3 class="search-group--title">{% trans 'Articles' %} ({{ results.articles|length }})</h3>
+                {% for hit in results.articles %}
+                    <a class="article_card" href="{% url 'blog:article_detail' hit.post.category.slug hit.post.slug %}">
+                        <div class="article_card--top">
+                            <div class="article_card--top-left"><p class="article_card--title">{{ hit.translation.title }}</p></div>
+                            {% if hit.post.category %}<p class="article_card--category">{{ hit.post.category }}</p>{% endif %}
+                        </div>
+                        {% if hit.translation.description %}<p class="article_card--description">{{ hit.translation.description }}</p>{% endif %}
+                    </a>
+                {% endfor %}
+            {% endif %}
+
+            {% if results.writeups %}
+                <h3 class="search-group--title">{% trans 'Writeups' %} ({{ results.writeups|length }})</h3>
+                {% for hit in results.writeups %}
+                    <a class="article_card" href="{% url 'infosec:writeup_detail' hit.post.category.slug hit.post.slug %}">
+                        <div class="article_card--top">
+                            <div class="article_card--top-left"><p class="article_card--title">{{ hit.translation.title }}</p></div>
+                            {% if hit.post.category %}<p class="article_card--category">{{ hit.post.category }}</p>{% endif %}
+                        </div>
+                        {% if hit.translation.description %}<p class="article_card--description">{{ hit.translation.description }}</p>{% endif %}
+                    </a>
+                {% endfor %}
+            {% endif %}
+
+            {% if results.lessons %}
+                <h3 class="search-group--title">{% trans 'Lessons' %} ({{ results.lessons|length }})</h3>
+                {% for hit in results.lessons %}
+                    <a class="article_card" href="{% url 'education:lesson_detail' hit.post.module.course.slug hit.post.module.slug hit.post.slug %}">
+                        <div class="article_card--top">
+                            <div class="article_card--top-left"><p class="article_card--title">{{ hit.translation.title }}</p></div>
+                            <p class="article_card--category">{{ hit.post.module.course }}</p>
+                        </div>
+                        {% if hit.translation.description %}<p class="article_card--description">{{ hit.translation.description }}</p>{% endif %}
+                    </a>
+                {% endfor %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Search across Articles, Writeups and Lessons translations from a single endpoint at /<lang>/search/?q=...

- Postgres backend uses SearchVector/SearchQuery/SearchRank with the per-language ts_config (french/english/italian) so stemming and stop-words match the user's content. Title weight A, description B, content C. Search type 'websearch' supports phrases and OR operators.
- SQLite (dev) falls back to icontains chains with a synthetic rank (3 title / 2 description / 1 content) so local development doesn't need Postgres.
- Results are scoped to translations in the active language only, consistent with the i18n_patterns layout where each language is a distinct content surface.
- Public visibility filter respected on Article/Writeup; Lesson is gated by parent Module/Course access at view time.
- Search page emits noindex,follow.
- Magnifying-glass icon in navbar links to the dedicated /search/ page (kept sober, no inline input).
- Bumps donasako submodule to dd005d0 which adds the matching templates and CSS.